### PR TITLE
Fix project type and description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "drupal/legacy-scaffold-assets",
-    "type": "metapackage",
-    "description": "Scaffold assets from drupal/drupal, for use with versions 8.0.x - 8.7.x",
+    "type": "library",
+    "description": "Scaffold assets from drupal/drupal; for use with versions 8.0.x - 8.7.x.",
     "license": "GPL-2.0-or-later"
 }


### PR DESCRIPTION
The project type should be "library" here, not "metapackage". Also, the description required a minor grammar adjustment.